### PR TITLE
navbarのスマホでのレイアウト崩れを解消

### DIFF
--- a/src/features/layouts/ContentSelector.tsx
+++ b/src/features/layouts/ContentSelector.tsx
@@ -1,9 +1,8 @@
 import { NavLink } from "react-router-dom";
 
 const ContentSelector = () => {
-  
-  return ( 
-    <div className="cursor-pointer rounded-full p-0 shadow-sm transition hover:shadow-md w-auto">
+  return (
+    <div className="cursor-pointer rounded-full p-0 shadow-sm transition hover:shadow-md w-auto min-w-max">
       <div className="flex flex-row items-center justify-between">
         <NavLink
           to="/articles"
@@ -17,6 +16,8 @@ const ContentSelector = () => {
             duration-300
             ${isActive ? "bg-yellow-800 bg-opacity-75" : "bg-white"}
             ${isActive ? "text-white" : "hover:bg-gray-200 bg-opacity-75" }
+            text-xs
+            sm:text-sm
             `
           }
         >
@@ -33,6 +34,8 @@ const ContentSelector = () => {
             duration-300
             ${isActive ? "bg-yellow-800 bg-opacity-75" : "bg-white"}
             ${isActive ? "text-white" : "hover:bg-gray-200 bg-opacity-75" }
+            text-xs
+            sm:text-sm
             `
           }
         >
@@ -50,6 +53,8 @@ const ContentSelector = () => {
             duration-300
             ${isActive ? "bg-yellow-800 bg-opacity-75" : "bg-white"}
             ${isActive ? "text-white" : "hover:bg-gray-200 bg-opacity-75" }
+            text-xs
+            sm:text-sm
             `
           }
         >

--- a/src/features/layouts/Navbar.tsx
+++ b/src/features/layouts/Navbar.tsx
@@ -1,30 +1,61 @@
 import ContentSelector from "./ContentSelector";
 import UserMenu from "./UserMenu";
 import Logo from "../../components/Elements/Logo";
+import useWindowSize from "../../hooks/useWindowSize";
 
 const Navbar = () => {
 
+  const [ width, height] = useWindowSize();
+
+  const body_if_width_large = (
+    <div
+      className="
+        flex
+        flex-row
+        items-center
+        justify-between
+        flex-wrap 
+        gap-3
+        md:gap-0
+      "
+    >
+      <Logo />
+      <ContentSelector />
+      <UserMenu />
+    </div>
+  );
+
+  const body_if_width_small = (
+    <>
+      <div
+        className="
+          flex
+          flex-row
+          items-center
+          justify-between
+          flex-wrap 
+          gap-3
+          md:gap-0
+        "
+      >
+        <Logo />
+        <UserMenu />
+      </div>
+      <div className="flex justify-center">
+          <ContentSelector />
+      </div>
+    </>
+  );
+
   return ( 
+    
     <div className="fixed w-full bg-white z-40 shadow-sm">
       <div className="
           p-2
           border-b-[1px]
         "
       >
-        <div
-          className="
-            flex
-            flex-row
-            items-center
-            justify-between
-            gap-3
-            md:gap-0
-          "
-        >
-          <Logo />
-          <ContentSelector />
-          <UserMenu />
-        </div>
+        { width > 550 ? body_if_width_large : body_if_width_small }
       </div>
     </div>
    );

--- a/src/hooks/useWindowSize.ts
+++ b/src/hooks/useWindowSize.ts
@@ -1,0 +1,18 @@
+import React, { useLayoutEffect, useState } from 'react';
+
+const useWindowSize = (): number[] => {
+  const [size, setSize] = useState([0, 0]);
+  useLayoutEffect(() => {
+    const updateSize = (): void => {
+      setSize([window.innerWidth, window.innerHeight]);
+    };
+
+    window.addEventListener('resize', updateSize);
+    updateSize();
+
+    return () => window.removeEventListener('resize', updateSize);
+  }, []);
+  return size;
+};
+
+export default useWindowSize;

--- a/src/pages/layouts/Layout.tsx
+++ b/src/pages/layouts/Layout.tsx
@@ -2,8 +2,10 @@ import { Outlet, ScrollRestoration, useNavigation } from "react-router-dom";
 import Navbar from "../../features/layouts/Navbar";
 import Footer from "../../features/layouts/Footer";
 import { Toaster } from "react-hot-toast";
+import useWindowSize from "../../hooks/useWindowSize";
 
 const Layout = () => {
+  const [ width, height ] = useWindowSize();
   const navigation = useNavigation();
   return ( 
     <div className="flex flex-col min-h-screen text-gray-700">
@@ -12,7 +14,7 @@ const Layout = () => {
       <div className={`
         flex-grow
         pb-10
-        pt-20
+        ${ width > 550 ? "pt-20" : "pt-24" }
         ${navigation.state === "idle" ? '' : 'opacity-50'}
       `}>
         <ScrollRestoration />


### PR DESCRIPTION
 useWindowSize フックを作り、画面サイズを取得。
画面widthが550px より下ならば、表示する内容を変更する。