### PR TITLE
フロントページのバグ解消

### DIFF
--- a/src/features/projects/ProjectCard.tsx
+++ b/src/features/projects/ProjectCard.tsx
@@ -110,9 +110,8 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
           :
             <></>
         }
-        
-        <div>{ getCategoryName(project.piety_target_id) }</div>
-        <div>{ getTargetName(project.piety_category_id)}</div>
+        <div>{ getCategoryName(project.piety_category_id) }</div>
+        <div>{ getTargetName(project.piety_target_id) }</div>
       </div>
     </div>
    );

--- a/src/pages/articles/Index.tsx
+++ b/src/pages/articles/Index.tsx
@@ -24,6 +24,7 @@ const IndexPage = () => {
               label="新規作成"
               onClick={()=>navigate("/articles/new")}
               rounded_full
+              small
             />
           </div>
           <ArticleSearchModal />
@@ -31,9 +32,14 @@ const IndexPage = () => {
       </div>
       { articles.length === 0
         ? 
-          <div className="flex justify-center mt-32 font-bold text-lg">
-            "No Coco found..."
-          </div>
+          <>
+            <div className="flex justify-center mt-32 font-bold text-lg">
+              <div>No Coco found...</div>
+            </div>
+            <div className="flex justify-center mt-10 font-bold text-lg">
+              <div>It's your turn.</div>
+            </div>
+          </>
         :
           <>
             <div className="

--- a/src/pages/forums/Index.tsx
+++ b/src/pages/forums/Index.tsx
@@ -25,6 +25,7 @@ const IndexPage = () => {
               label="新規作成"
               onClick={()=>navigate("/articles/new")}
               rounded_full
+              small
             />
           </div>
           <ForumSearchModal />
@@ -32,9 +33,14 @@ const IndexPage = () => {
       </div>
       { forums.length === 0
         ?
-          <div className="flex justify-center mt-32 font-bold text-lg">
-            "No forum found..."
-          </div>
+          <>
+            <div className="flex justify-center mt-32 font-bold text-lg">
+              No forum found...
+            </div>
+            <div className="flex justify-center mt-10 font-bold text-lg">
+              It's your turn.
+            </div>
+          </>
         :
           <>
             <div className="

--- a/src/pages/forums/Index.tsx
+++ b/src/pages/forums/Index.tsx
@@ -9,7 +9,7 @@ import ForumSearchModal from "../../components/Modals/ForumSearchModal";
 export const loader: LoaderFunction = async ({ request } :LoaderFunctionArgs) => {
   const forums = await getForums((new URL(request.url)));
 
-  return {forums: forums.data, pagination_info: forums.pagination_info };
+  return {forums: forums.data, pagination_info: forums.pagination_info, q: forums.q };
 } 
 
 const IndexPage = () => {

--- a/src/pages/profiles/Show.tsx
+++ b/src/pages/profiles/Show.tsx
@@ -159,18 +159,20 @@ const ShowPage = () => {
         <UserInfoHeader user={profile}/>
         
         <div className="flex justify-center mt-40">
-          <div className="w-40 mx-20">
+          <div className="w-20 mx-5 md:w-40 md:mx-20">
             <Button 
               label="編集する"
               onClick={onClickModeButton}
+              small
             />
           </div>
 
-          <div className="w-40 mx-20">
+          <div className="w-20 mx-5 md:w-40 md:mx-20">
             <Button 
               label="退会する"
               onClick={deleteUserAction}
               outline
+              small
             />
           </div>
         </div>

--- a/src/pages/projects/Index.tsx
+++ b/src/pages/projects/Index.tsx
@@ -25,6 +25,7 @@ const IndexPage = () => {
               label="新規作成"
               onClick={()=>navigate("/projects/new")}
               rounded_full
+              small
             />
           </div>
           <ProjectSearchModal />
@@ -33,9 +34,14 @@ const IndexPage = () => {
 
       { projects.length === 0
         ? 
-          <div className="flex justify-center mt-32 font-bold text-lg">
-            "No Project found..."
-          </div>
+          <>
+            <div className="flex justify-center mt-32 font-bold text-lg">
+              No Project found...
+            </div>
+            <div className="flex justify-center mt-10 font-bold text-lg">
+              It's your turn.
+            </div>
+          </>
         :
           <>
             <div className="


### PR DESCRIPTION
### index画面の0件時の表示変更
文言の修正

### loaderでのqパラメータの取得忘れ対応
- loader_funcでq を取得し、loaderDataに渡すよう修正


### project画面のカテゴリ・ターゲットがずれているのを修正
- カテゴリ・ターゲットをそれぞれ正しく設定

 
### プロフィールページのボタン調整
- 画面サイズが小さい場合、表示がつぶれていたので修正
