### PR TITLE
Formのvalidation強化

### DIFF
--- a/src/features/articles/ArticleForm.tsx
+++ b/src/features/articles/ArticleForm.tsx
@@ -180,6 +180,7 @@ const ArticleForm: React.FC<ArticleFormProps> = ({
                 value={article.title}
                 required
                 onChange={onChangeTitle}
+                maxLength={30}
               />
             </div>
             <div className="thumbnail-wrapper mb-10">

--- a/src/features/forums/ForumForm.tsx
+++ b/src/features/forums/ForumForm.tsx
@@ -164,6 +164,7 @@ const ForumForm: React.FC<ForumFormProps> = ({
               value={forum.title}
               required
               onChange={onChangeTitle}
+              maxLength={30}
             />
           </div>
           <hr className="my-6"/>

--- a/src/features/projects/ProjectForm.tsx
+++ b/src/features/projects/ProjectForm.tsx
@@ -159,6 +159,7 @@ const ProjectForm: React.FC<ProjectFormProps> = ({
               value={project.title}
               required
               onChange={onChangeTitle}
+              maxLength={30}
             />
           </div>
 

--- a/src/pages/articles/Edit.tsx
+++ b/src/pages/articles/Edit.tsx
@@ -83,12 +83,14 @@ const EditPage = () => {
       }
     }
 
-
-
     formData.append("article[piety_category_id]", formArticle.piety_category_id);
     formData.append("article[piety_target_id]", formArticle.piety_target_id);
-    if (formArticle.days) formData.append("article[days]", formArticle.days);
-    if (formArticle.cost) formData.append("article[cost]", formArticle.cost);
+
+    formData.append("article[days]", formArticle.days)
+    formData.append("article[cost]", formArticle.cost)
+    // 元々取得したformArticle.days が nullの場合、nullで送ってしまうとRailsで0扱いされるので、nullの場合は文字なしで送る。 costも同様
+    if(formArticle.days==null){ formData.append("article[days]", '');} 
+    if(formArticle.cost==null){ formData.append("article[cost]", '');} 
 
     await toast.promise(
       updateArticle(token, articleId, formData), 

--- a/src/pages/forums/Edit.tsx
+++ b/src/pages/forums/Edit.tsx
@@ -74,6 +74,9 @@ const EditPage = () => {
     formData.append("forum[piety_target_id]", formForum.piety_target_id);
     formData.append("forum[days]", formForum.days);
     formData.append("forum[cost]", formForum.cost);
+    // 元々取得したformForum.days が nullの場合、nullで送ってしまうとRailsで0扱いされるので、nullの場合は文字なしで送る。 costも同様
+    if(formForum.days==null){ formData.append("forum[days]", '');} 
+    if(formForum.cost==null){ formData.append("forum[cost]", '');} 
     
     await toast.promise(
       updateForum(token, forumId, formData), 

--- a/src/pages/forums/Index.tsx
+++ b/src/pages/forums/Index.tsx
@@ -23,7 +23,7 @@ const IndexPage = () => {
           <div className="w-60">
             <Button 
               label="新規作成"
-              onClick={()=>navigate("/articles/new")}
+              onClick={()=>navigate("/forums/new")}
               rounded_full
               small
             />

--- a/src/pages/projects/Edit.tsx
+++ b/src/pages/projects/Edit.tsx
@@ -78,6 +78,8 @@ const EditPage = () => {
     formData.append("project_form[cost]", formProject.cost);
     formData.append("project_form[tasks]", JSON.stringify(formProject.tasks));
     formData.append("project_form[actions]", JSON.stringify(formProject.actions));
+    // 元々取得したformProject.cost が nullの場合、nullで送ってしまうとRailsで0扱いされるので、nullの場合は文字なしで送る。
+    if(formProject.cost==null){ formData.append("project_form[cost]", '');} 
 
     await toast.promise(
       updateProject(token, projectId ,formData), 


### PR DESCRIPTION
**メインオブジェクトのフォームにバリデーションを追加**
- titleはmax30字

**editのformでのcost/daysで空欄なのに０で更新される問題を修正**
- Railsでnil だと、formobjectでnullになる、そのまま送信すると、Rails側で、"null" は0として保存される。 
   なので、cost==null ならば、"null"ではなく''を送るように処理を追加。
   days も同様
